### PR TITLE
Add support for react > 16 : react, react-native and react-native-svg peer deps resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,8 +64,8 @@
     "typescript": "^3.8.3"
   },
   "resolutions": {
-    "react": "~16.9.0",
-    "react-native": "~0.61.5",
-    "react-native-svg": "~9.13.3"
+    "react": ">=16.9.0",
+    "react-native": ">=0.61.5",
+    "react-native-svg": ">=9.13.3"
   }
 }


### PR DESCRIPTION
I've changed the peer dependency resolutions to new majors versions compatibility for
react
react-native
react-native-svg

### Please read and mark the following check list before creating a pull request:

 - [X] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [X] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:
Allow using react-native-eva-icons in a project with major version of react > 16.
And avoid using --legacy-peer-deps flag in npm install.